### PR TITLE
Retrieve tools and tools' attributes

### DIFF
--- a/retrieve_categories.py
+++ b/retrieve_categories.py
@@ -1,3 +1,6 @@
+# module for the retrieval of tools and tools' attributes from
+# usegalaxy.eu web interface
+
 import dryscrape
 import re
 import urllib

--- a/retrieve_categories.py
+++ b/retrieve_categories.py
@@ -1,0 +1,34 @@
+#"//div[@class = 'toolSectionWrapper']/div[@class = 'toolSectionTitle']/text()") # takes the category
+#"//div[@class = 'toolSectionWrapper']//div[@class = 'toolTitle']//a/text()") # takes a tool's label
+#"//div[@class = 'toolSectionWrapper']//div[@class = 'toolTitle']//a/@href") # takes a tool's URL
+
+import dryscrape
+import urllib
+from bs4 import BeautifulSoup
+from lxml import etree
+from StringIO import StringIO
+
+USEGALAXY_EU = "https://usegalaxy.eu"
+
+# visit usegalaxy.eu and handle its javascript calls
+dryscrape.start_xvfb()
+session = dryscrape.Session()
+session.visit(USEGALAXY_EU)
+
+if session.status_code() == 200:
+
+    # correct ieventually broken HTML opening/closing tags
+    response = BeautifulSoup(session.body(), "lxml")
+    html = response.prettify().encode('utf-8')
+
+    # parse the retrieved HML
+    parser = etree.HTMLParser()
+    tree = etree.parse(StringIO(html), parser)
+
+    # retrieve each tool's URL
+    tools = tree.xpath("//div[@class = 'toolSectionWrapper']//div[@class = 'toolTitle']//a/@href")
+
+
+    for tool in tools:
+        t.append(urllib.unquote(tool))
+

--- a/retrieve_categories.py
+++ b/retrieve_categories.py
@@ -1,14 +1,18 @@
-#"//div[@class = 'toolSectionWrapper']/div[@class = 'toolSectionTitle']/text()") # takes the category
-#"//div[@class = 'toolSectionWrapper']//div[@class = 'toolTitle']//a/text()") # takes a tool's label
-#"//div[@class = 'toolSectionWrapper']//div[@class = 'toolTitle']//a/@href") # takes a tool's URL
-
 import dryscrape
+import re
 import urllib
 from bs4 import BeautifulSoup
 from lxml import etree
 from StringIO import StringIO
 
 USEGALAXY_EU = "https://usegalaxy.eu"
+CATEGORY = "category"
+LABEL    = "label"
+NAME     = "name"
+URL      = "url"
+result = {}
+
+pp = pprint.PrettyPrinter(indent=4)
 
 # visit usegalaxy.eu and handle its javascript calls
 dryscrape.start_xvfb()
@@ -17,7 +21,7 @@ session.visit(USEGALAXY_EU)
 
 if session.status_code() == 200:
 
-    # correct ieventually broken HTML opening/closing tags
+    # correct eventually broken HTML opening/closing tags
     response = BeautifulSoup(session.body(), "lxml")
     html = response.prettify().encode('utf-8')
 
@@ -25,10 +29,39 @@ if session.status_code() == 200:
     parser = etree.HTMLParser()
     tree = etree.parse(StringIO(html), parser)
 
-    # retrieve each tool's URL
-    tools = tree.xpath("//div[@class = 'toolSectionWrapper']//div[@class = 'toolTitle']//a/@href")
+    # retrieve each tool section
+    tool_sections = tree.xpath("//div[@class = 'toolSectionWrapper']")
 
+    for tool_section in tool_sections:
 
-    for tool in tools:
-        t.append(urllib.unquote(tool))
+        category = None
+        label    = None
+        name     = None
+        url      = None
+
+        # retrieve the tool section's category
+        category = tool_section.xpath("./div[@class = 'toolSectionTitle']/a/span/text()")[0].rstrip().lstrip()
+
+        # retrieve the tool list
+        tools = tool_section.xpath("./div[@class = 'toolSectionBody']/div[@class = 'toolTitle']")
+
+        for tool in tools:
+
+            # retrieve the tool's label
+            label = tool.xpath(".//a/span[@class = 'tool-old-link']/text()")[0].rstrip().lstrip()
+
+            # retrieve the tool's URL
+            url = re.sub("^.*tool_id=", "", urllib.unquote(tool.xpath(".//a/@href")[0].rstrip().lstrip()) )
+
+            # retrieve the tool ONLY if its URL refers to the toolshed
+            if re.match("^.*toolshed", url) :
+
+                # retrieve the tool's name
+                name = url.split("/")[::-1][1]
+
+                # track the new tool entry
+                if name not in result.keys():
+                    result[name] = { url: {LABEL: label, CATEGORY: category}}
+                else:
+                    result[name][url] = {LABEL: label, CATEGORY: category}
 


### PR DESCRIPTION
The code implements a scraper for the usegalaxy.eu web interface. In particular, it parses the HTML page, and retrieves the list of tools, their category, label, and URL.
Since each tool can belong to multiple categories, and hold more than one URL, results are organised as dictionaries of dictionaries. Examples:
- `muscle` belongs only to 1 category, and holds 1 URL:
```
'muscle': {
    'toolshed.g2.bx.psu.edu/repos/crs4/muscle/muscle/0.0.11': {
        'category': 'Multiple Alignments',
        'label': 'MUSCLE'
    }
}
```
- `multiqc` belongs only to 3 categories, and holds 3 URLs:
```
'multiqc': {
    'toolshed.g2.bx.psu.edu/repos/engineson/multiqc/multiqc/1.0.0.0': {
        'category': 'Quality Control',
        'label': 'multiqc'
    },
    'toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.3.1': {
        'category': 'Quality Control',
        'label': 'MultiQC'},
    'toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.5.0': {
        'category': 'FASTA/FASTQ manipulation',
        'label': 'MultiQC'
    }
}
```