### PR TITLE
tool attribute retrieval split into functions

### DIFF
--- a/retrieve_categories.py
+++ b/retrieve_categories.py
@@ -8,6 +8,7 @@ from bs4 import BeautifulSoup
 from lxml import etree
 from StringIO import StringIO
 
+
 USEGALAXY_EU = "https://usegalaxy.eu"
 CATEGORY = "category"
 LABEL    = "label"
@@ -15,27 +16,50 @@ NAME     = "name"
 URL      = "url"
 result = {}
 
-pp = pprint.PrettyPrinter(indent=4)
+# XPATH queries for retrieving tool attributes from the usegalaxy.eu
+# web interface
+XPATH_SECTION  = "//div[@class = 'toolSectionWrapper']"
+XPATH_CATEGORY = "./div[@class = 'toolSectionTitle']/a/span/text()"
+XPATH_TOOLS    = "./div[@class = 'toolSectionBody']/div[@class = 'toolTitle']"
+XPATH_LABEL    = ".//a/span[@class = 'tool-old-link']/text()"
+XPATH_URL      = ".//a/@href"
 
-# visit usegalaxy.eu and handle its javascript calls
-dryscrape.start_xvfb()
-session = dryscrape.Session()
-session.visit(USEGALAXY_EU)
 
-if session.status_code() == 200:
+# retrieve the tools catalog
+#
+def get_tool_catalog():
+    tool_catalog = None
 
-    # correct eventually broken HTML opening/closing tags
-    response = BeautifulSoup(session.body(), "lxml")
-    html = response.prettify().encode('utf-8')
+    # visit usegalaxy.eu and handle its javascript calls
+    dryscrape.start_xvfb()
+    session = dryscrape.Session()
+    session.visit(USEGALAXY_EU)
 
-    # parse the retrieved HML
-    parser = etree.HTMLParser()
-    tree = etree.parse(StringIO(html), parser)
+    if session.status_code() == 200:
 
-    # retrieve each tool section
-    tool_sections = tree.xpath("//div[@class = 'toolSectionWrapper']")
+        # correct eventually broken HTML opening/closing tags
+        response = BeautifulSoup(session.body(), "lxml")
+        html = response.prettify().encode('utf-8')
 
-    for tool_section in tool_sections:
+        # parse the retrieved HML
+        parser = etree.HTMLParser()
+        tree = etree.parse(StringIO(html), parser)
+
+        # retrieve each tool section
+        tool_catalog = tree.xpath(XPATH_SECTION)
+
+    return tool_catalog
+
+
+
+# retrieve all attributes of each tool
+#
+def get_attributes():
+    result = {}
+
+    tool_catalog = get_tool_catalog()
+
+    for section in tool_catalog:
 
         category = None
         label    = None
@@ -43,18 +67,18 @@ if session.status_code() == 200:
         url      = None
 
         # retrieve the tool section's category
-        category = tool_section.xpath("./div[@class = 'toolSectionTitle']/a/span/text()")[0].rstrip().lstrip()
+        category = section.xpath(XPATH_CATEGORY)[0].rstrip().lstrip()
 
         # retrieve the tool list
-        tools = tool_section.xpath("./div[@class = 'toolSectionBody']/div[@class = 'toolTitle']")
+        tools = section.xpath(XPATH_TOOLS)
 
         for tool in tools:
 
             # retrieve the tool's label
-            label = tool.xpath(".//a/span[@class = 'tool-old-link']/text()")[0].rstrip().lstrip()
+            label = tool.xpath(XPATH_LABEL)[0].rstrip().lstrip()
 
             # retrieve the tool's URL
-            url = re.sub("^.*tool_id=", "", urllib.unquote(tool.xpath(".//a/@href")[0].rstrip().lstrip()) )
+            url = re.sub("^.*tool_id=", "", urllib.unquote(tool.xpath(XPATH_URL)[0].rstrip().lstrip()) )
 
             # retrieve the tool ONLY if its URL refers to the toolshed
             if re.match("^.*toolshed", url) :
@@ -68,3 +92,49 @@ if session.status_code() == 200:
                 else:
                     result[name][url] = {LABEL: label, CATEGORY: category}
 
+    return result
+
+
+
+# retrieve only the names and categories of each tool
+#
+def get_names_categories():
+    result = {}
+
+    tool_catalog = get_tool_catalog()
+
+    for section in tool_catalog:
+
+        category = None
+        name     = None
+
+        # retrieve the tool section's category
+        category = section.xpath(XPATH_CATEGORY)[0].rstrip().lstrip()
+
+        # retrieve the tool list
+        tools = section.xpath(XPATH_TOOLS)
+
+        for tool in tools:
+
+            # retrieve the tool's URL
+            url = re.sub("^.*tool_id=", "", urllib.unquote(tool.xpath(XPATH_URL)[0].rstrip().lstrip()) )
+
+            # retrieve the tool ONLY if its URL refers to the toolshed
+            if re.match("^.*toolshed", url) :
+
+                # retrieve the tool's name
+                name = url.split("/")[::-1][1]
+
+                # track the new tool entry
+                if name not in result.keys():
+                    result[name] = [category]
+                else:
+                    categories = result[name]
+                    categories.append(category)
+                    result[name] = categories
+
+    return result
+
+if __name__ == '__main__':
+    result = get_attributes()
+    print result

--- a/retrieve_categories.py
+++ b/retrieve_categories.py
@@ -134,7 +134,3 @@ def get_names_categories():
                     result[name] = categories
 
     return result
-
-if __name__ == '__main__':
-    result = get_attributes()
-    print result


### PR DESCRIPTION
Previously, the scraper collected each tool's attribute in one dictionary. However, some informations might be useless.
I therefore reorganised the scraper, to return specific sets of attributes for all galaxy.eu tool